### PR TITLE
Support multi char in one data packet

### DIFF
--- a/coco/interactive.py
+++ b/coco/interactive.py
@@ -79,8 +79,15 @@ class InteractiveServer(object):
                     g.client_channel.send('')
                     continue
 
+                # handle shell expect
+                multi_char_with_enter = False
+                if len(data) > 1 and data[-1] in self.ENTER_CHAR:
+                    g.client_channel.send(data)
+                    input_data.append(data[:-1])
+                    multi_char_with_enter = True
+
                 # If user type ENTER we should get user input
-                if data in self.ENTER_CHAR:
+                if data in self.ENTER_CHAR or multi_char_with_enter:
                     g.client_channel.send(wr('', after=2))
                     option = parser.parse_input(b''.join(input_data))
                     return option.strip()


### PR DESCRIPTION
程序中判断是否存在enter符号的时候只是对单个字符进行判断
```python
if data in self.ENTER_CHAR:
    pass
```
xshell发送expect时候，是多个字符同时发送，导致不能识别到`enter`符号

ps：使用expect好处是，可以快速的跳转到对应的机器