### PR TITLE
变量名称不一致

### DIFF
--- a/coco/proxy.py
+++ b/coco/proxy.py
@@ -117,7 +117,7 @@ class ProxyServer(object):
 
         data = {"user": user.username, "asset": asset.ip,
                 "system_user": system_user.username,  "login_type": "ST",
-                "date_start": time.time(), "is_failed": 0}
+                "date_start": time.time(), "was_failed": 0}
         self.proxy_log_id = proxy_log_id = self.service.send_proxy_log(data)
         self.app.proxy_list[proxy_log_id] = self.client_channel, self.backend_channel
         try:


### PR DESCRIPTION
proxy.py中使用的是is_failed, jms sdk 中使用的是was_failed

    def send_proxy_log(self, data):
        """
        :param data: 格式如下
        data = {
            "user": "username",
            "asset": "name",
            "system_user": "web",
            "login_type": "ST",
            "was_failed": False,
            "date_start": timestamp,
        }
        """
        assert isinstance(data.get('date_start'), (int, float))
        data['date_start'] = timestamp_to_datetime_str(data['date_start'])
        data['was_failed'] = 1 if data.get('was_failed') else 0

        r, content = self.post('send-proxy-log', data=data, use_auth=True)
        if r.status_code != 201:
            logging.warning('Send proxy log failed: %s' % content)
            return None
        else:
            return content['id']