### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -19,7 +19,7 @@ itsdangerous==0.24
 Jinja2==2.10
 jmespath==0.9.3
 jms-storage==0.0.18
-jumpserver-python-sdk==0.0.50
+jumpserver-python-sdk==0.0.48
 MarkupSafe==1.0
 oss2==2.4.0
 paramiko==2.4.1


### PR DESCRIPTION
Collecting jumpserver-python-sdk==0.0.50 (from -r requirements.txt (line 22))
  Could not find a version that satisfies the requirement jumpserver-python-sdk==0.0.50 (from -r requirements.txt (line 22)) (from versions: 0.0.1, 0.0.2, 0.0.3, 0.0.6, 0.0.7, 0.0.8, 0.0.9, 0.0.10, 0.0.11, 0.0.12, 0.0.13, 0.0.14, 0.0.15, 0.0.16, 0.0.17, 0.0.18, 0.0.19, 0.0.20, 0.0.21, 0.0.22, 0.0.23, 0.0.24, 0.0.25, 0.0.26, 0.0.27, 0.0.28, 0.0.29, 0.0.30, 0.0.31, 0.0.32, 0.0.33, 0.0.34, 0.0.35, 0.0.36, 0.0.37, 0.0.38, 0.0.39, 0.0.40, 0.0.41, 0.0.42, 0.0.43, 0.0.44, 0.0.45, 0.0.46, 0.0.47, 0.0.48)