### PR TITLE
开启coco ssh server对ssh-agent信息的处理

### DIFF
--- a/coco/connection.py
+++ b/coco/connection.py
@@ -96,6 +96,7 @@ class SSHConnection:
     def get_channel(self, asset, system_user, term="xterm", width=80, height=24):
         ssh, sock, msg = self.get_ssh_client(asset, system_user)
         if ssh:
+            paramiko.agent.AgentRequestHandler(ssh)
             chan = ssh.invoke_shell(term, width=width, height=height)
             return chan, sock, None
         else:


### PR DESCRIPTION
使用 ssh -A user@host 登录 ssh server前已经加载了ssh key 希望登录目标服务器后继续保持，需要开启ssh-agent自动转发